### PR TITLE
Fix MMGCN config file:MMGCN.yaml

### DIFF
--- a/src/configs/model/MMGCN.yaml
+++ b/src/configs/model/MMGCN.yaml
@@ -1,7 +1,7 @@
 embedding_size: 64
 n_layers: 2
 reg_weight: [0, 0.00001, 0.0001, 0.001, 0.01, 0.1]
-learning_rate: [0.0001, 0.0005, 0.001.0.005, 0.01]
+learning_rate: [0.0001, 0.0005, 0.001, 0.005, 0.01]
 
 hyper_parameters: ["reg_weight", "learning_rate"]
 


### PR DESCRIPTION
In MMGCN.yaml, learning_rate contains invalid value "0.001.0.005" and it might be a typo which causes the model error.